### PR TITLE
Fix shebang lines in init scripts

### DIFF
--- a/docker/init.sh
+++ b/docker/init.sh
@@ -1,4 +1,4 @@
-#!bin/bash
+#!/bin/bash
 
 if [ -d "/home/frappe/frappe-bench/apps/frappe" ]; then
     echo "Bench already exists, skipping init"

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -1,4 +1,4 @@
-#!bin/bash
+#!/bin/bash
 
 set -e
 


### PR DESCRIPTION
## Summary
- correct bash shebang in `docker/init.sh` and `scripts/init.sh`
- ensure both scripts have a newline at the end

## Testing
- `pytest -q` *(fails: command not found)*